### PR TITLE
Delete CNAME

### DIFF
--- a/src/main/website/CNAME
+++ b/src/main/website/CNAME
@@ -1,1 +1,0 @@
-opt4j.org


### PR DESCRIPTION
We don't own opt4j.org anymore.