### PR TITLE
GitHub Action to Deploy Release Archives to Github Release

### DIFF
--- a/.github/workflows/gh-release-assets.yml
+++ b/.github/workflows/gh-release-assets.yml
@@ -1,0 +1,29 @@
+# This workflow will deploy the Opt4J release archives to a newly created release
+
+name: Opt4J Release Assets
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+    - name: Yet Another Upload Release Asset Action
+      uses: shogo82148/actions-upload-release-asset@v1.2.5
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./build/distributions/*
+


### PR DESCRIPTION
We may need to add an alpha tag and create a temporal release to check the actions. Will need to improve on my offline GitHub Action workflow to avoid these "test" commits in the future. :-(