### PR TITLE
Leading v in git tag (v1.2.3) is removed from version name (1.2.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ def getVersionName = {
 	version=stdout.toString().trim()
 	if (version.count('-') > 1 || version.isEmpty())
 		version += '-SNAPSHOT'
+	if (version.getAt(0) == 'v')
+		version = version.substring(1)
 	return version
 }
 version=getVersionName()


### PR DESCRIPTION
Adresses issue #82 