### PR TITLE
add Jacoco test report as .csv

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,7 +91,7 @@ subprojects {
 		reports {
 			html.enabled = true
 			xml.enabled = true
-			csv.enabled = false
+			csv.enabled = true
 		}
 	}
 }


### PR DESCRIPTION
Currently checking for additional analysis tools and integrations, some of which require Jacoco test reports as .csv instead of .xml. I don't think providing the report as .csv does any harm here and may ease integration.