### PR TITLE
91 GitHub actions version bump

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,11 +12,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: 'zulu'
+        java-version: '11'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle

--- a/.github/workflows/gh-release-assets.yml
+++ b/.github/workflows/gh-release-assets.yml
@@ -12,17 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: 'zulu'
+        java-version: '11'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build
     - name: Yet Another Upload Release Asset Action
-      uses: shogo82148/actions-upload-release-asset@v1.2.5
+      uses: shogo82148/actions-upload-release-asset@v1
       with:
         upload_url: ${{ github.event.release.upload_url }}
         asset_path: ./build/distributions/*

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,9 +26,6 @@ jobs:
       run: ./gradlew build
     - name: Generate the test report
       run: ./gradlew jacocorootreport
-    - uses: actions/setup-go@v5
-      with:
-        go-version: '1.20'
     - name: Run codacy-coverage-reporter
       uses: codacy/codacy-coverage-reporter-action@master
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -26,6 +26,9 @@ jobs:
       run: ./gradlew build
     - name: Generate the test report
       run: ./gradlew jacocorootreport
+    - uses: actions/setup-go@v5
+      with:
+        go-version: '1.20'
     - name: Run codacy-coverage-reporter
       uses: codacy/codacy-coverage-reporter-action@master
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,11 +14,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 11
+        distribution: 'zulu'
+        java-version: '11'
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle


### PR DESCRIPTION
Switched to GitHub Action Node 20 wherever possible. It seems Codacy still launches its own setup-go@v3 which also creates a warning on our side, but the Codacy integration seems to still be alive and well.